### PR TITLE
fix: remove deprecated @angular/animations provider

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -2,13 +2,10 @@ import { ApplicationConfig } from '@angular/core';
 import { provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { routes } from './app.routes';
-import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 
 export const appConfig: ApplicationConfig = {
   providers: [
     provideHttpClient(),
     provideRouter(routes),
-    provideAnimationsAsync(),
-    provideAnimationsAsync(),
   ],
 };


### PR DESCRIPTION
Overlooked in [refactor: refactor animations to css](https://github.com/michael-mccurtin/os8wj0rzzj8wnf1adi0vy4p9iny5metc/commit/819e532d15880b02da801c5f741afc8b06ae3bf6) commit